### PR TITLE
fix : summary 필드 추가

### DIFF
--- a/src/main/java/com/tave/alarmissue/news/domain/News.java
+++ b/src/main/java/com/tave/alarmissue/news/domain/News.java
@@ -60,6 +60,9 @@ public class News {
     @Column
     private Long voteNum;
 
+    @Column
+    private String summary;
+
     @Builder
     public News(String title,
                 String url,
@@ -71,7 +74,8 @@ public class News {
                 Double sentiment,
                 Long view,
                 Long commentNum,
-                Long voteNum) {
+                Long voteNum,
+                String summary) {
         this.title = title;
         this.url = url;
         this.imageUrl = imageUrl;
@@ -83,6 +87,7 @@ public class News {
         this.view = view;
         this.commentNum = commentNum;
         this.voteNum = voteNum;
+        this.summary = summary;
     }
 
     public void incrementView(){

--- a/src/main/java/com/tave/alarmissue/news/dto/response/NewsDetailResponseDto.java
+++ b/src/main/java/com/tave/alarmissue/news/dto/response/NewsDetailResponseDto.java
@@ -23,4 +23,5 @@ public class NewsDetailResponseDto {
     private Long view;
     private Long commentNum;
     private Long voteNum;
+    private String summary;
 }

--- a/src/main/java/com/tave/alarmissue/news/service/DaumNewsCrawlService.java
+++ b/src/main/java/com/tave/alarmissue/news/service/DaumNewsCrawlService.java
@@ -118,6 +118,7 @@ public class DaumNewsCrawlService {
                         .view(0L)
                         .commentNum(0L)
                         .voteNum(0L)
+                        .summary(null)
                         .build();
 
                 newsToSave.add(news);

--- a/src/main/java/com/tave/alarmissue/news/service/NaverNewsCrawlService.java
+++ b/src/main/java/com/tave/alarmissue/news/service/NaverNewsCrawlService.java
@@ -135,6 +135,7 @@ public class NaverNewsCrawlService {
                         .view(0L)
                         .commentNum(0L)
                         .voteNum(0L)
+                        .summary(null)
                         .build();
 
                     newsToSave.add(news);


### PR DESCRIPTION

## #⃣ 연관된 이슈

> close #75 

## 📝 작업 내용

> - news 엔티티 내부에 summary 필드 추가
<img width="1107" height="615" alt="스크린샷 2025-07-12 오후 8 56 14" src="https://github.com/user-attachments/assets/78b18d67-7782-44f4-a5b4-4c7bcabab2b3" />


