### PR TITLE
fix: 조회수 순 뉴스 정렬 수정

### DIFF
--- a/src/main/java/com/tave/alarmissue/news/repository/NewsRepository.java
+++ b/src/main/java/com/tave/alarmissue/news/repository/NewsRepository.java
@@ -25,10 +25,10 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     List<News> findAll();
 
     Slice<News> findAllByOrderByDateDesc(Pageable pageable);
-    Slice<News> findAllByOrderByViewDesc(Pageable pageable);
+    Slice<News> findAllByOrderByViewDescDateDesc(Pageable pageable);
 
     Slice<News> findByThemaOrderByDateDesc(Thema thema,Pageable pageable);
-    Slice<News> findByThemaOrderByViewDesc(Thema thema,Pageable pageable);
+    Slice<News> findByThemaOrderByViewDescDateDesc(Thema thema,Pageable pageable);
 
     // 키워드 포함 뉴스 개수
     @Query("SELECT COUNT(n) FROM News n WHERE LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%'))")

--- a/src/main/java/com/tave/alarmissue/news/service/NewsService.java
+++ b/src/main/java/com/tave/alarmissue/news/service/NewsService.java
@@ -34,7 +34,7 @@ public class NewsService {
 //        Slice<News> newsSlice=newsRepository.findAll(sortType,pageable);
         Slice<News> newsSlice=switch(sortType){
             case LATEST -> newsRepository.findAllByOrderByDateDesc(pageable);
-            case VIEWEST -> newsRepository.findAllByOrderByViewDesc(pageable);
+            case VIEWEST -> newsRepository.findAllByOrderByViewDescDateDesc(pageable);
         };
         List<NewsResponseDto> content=newsSlice.getContent()
                 .stream().map(newsConverter::toDto)
@@ -46,7 +46,7 @@ public class NewsService {
     public SliceResponseDto<NewsResponseDto> getAllThemaNews(NewsSortType sortType,Thema thema,Pageable pageable) {
         Slice<News> newsSlice=switch(sortType){
             case LATEST -> newsRepository.findByThemaOrderByDateDesc(thema,pageable);
-            case VIEWEST -> newsRepository.findByThemaOrderByViewDesc(thema,pageable);
+            case VIEWEST -> newsRepository.findByThemaOrderByViewDescDateDesc(thema,pageable);
         };
         List<NewsResponseDto> content=newsSlice.getContent()
                 .stream().map(newsConverter::toDto)


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #92 

## 📝 작업 내용

조회수 같은 뉴스는 최신순 정렬로 수정
<img width="1564" height="874" alt="image" src="https://github.com/user-attachments/assets/e189586a-1ecb-438c-9063-924784bc7d22" />


## 💬 리뷰 요구사항(선택)


